### PR TITLE
Created defaults variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+ssl_certificates:[]
+# ssl_certificates: 
+#   - host.domain.tld
+virtual_hosts: []
+
+# virtual_hosts:
+#   - {
+#       name: "host.domain.tld",
+#       admin_email: "user@domain.tld",
+#       document_root: "/var/www/html",
+#       ssl: {
+#         enabled: True,
+#         certificate: /etc/pki/tls/certs/host.domain.tld.crt,
+#         key: /etc/pki/tls/key/host.domain.tld.key,
+#         chain_certificate: /etc/pki/tls/certs/host.domain.tld.interm.crt
+#       }
+#     }
+#
+# example of ssl certficate:
+# ssl_certs:
+#   host.domain.tld:
+#     cert: |
+#       -----BEGIN CERTIFICATE-----
+#       sdfadsfasdfasdfasdf
+#       -----END CERTIFICATE-----
+#     interim: |
+#       -----BEGIN CERTIFICATE-----
+#       ds;fkljkasldfj;lkasjdfljasd;fjasdf
+#       -----END CERTIFICATE-----
+#     key: |
+#       -----BEGIN RSA PRIVATE KEY-----
+#       MIIEow...
+#       -----END RSA PRIVATE KEY-----
+#


### PR DESCRIPTION
We should set some defaults for these or else the role will fail.  Created empty defaults for ssl_certificates and virtual_hosts.

I also added an example (in comments) with how to define ssl_certs